### PR TITLE
Baseline for ACPAPI Directory XDM from original pull request #96

### DIFF
--- a/schemas/content/directory.description.md
+++ b/schemas/content/directory.description.md
@@ -1,0 +1,1 @@
+A directory is a container of content items (for instance assets) and other directories.

--- a/schemas/content/directory.example.1.json
+++ b/schemas/content/directory.example.1.json
@@ -1,0 +1,37 @@
+{
+    "name": "example",
+    "path": "/content/example",
+    "@type": "https://ns.adobe.com/xdm/content/directory",
+    "repository_created_date": "2017-09-26T13:27:36+00:00",
+    "repository_last_modified_date": "2017-09-26T13:31:19+00:00",
+    "children": [
+        {
+            "name": "subdirectory0",
+            "path": "/content/example/subdirectory0",
+            "@type": "https://ns.adobe.com/xdm/content/directory",
+            "repository_created_date": "2017-09-26T13:27:36+00:00",
+            "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
+        },
+        {
+            "name": "subdirectory1",
+            "path": "/content/example/subdirectory1",
+            "@type": "https://ns.adobe.com/xdm/content/directory",
+            "repository_created_date": "2017-09-26T13:27:36+00:00",
+            "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
+        },
+        {
+            "name": "image0",
+            "path": "/content/example/image0",
+            "@type": "http://ns.adobe.com/xdm/asset",
+            "repository_created_date": "2017-09-26T13:27:36+00:00",
+            "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
+        },
+        {
+            "name": "image1",
+            "path": "/content/example/image1",
+            "@type": "http://ns.adobe.com/xdm/asset",
+            "repository_created_date": "2017-09-26T13:27:36+00:00",
+            "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
+        }
+    ]
+}

--- a/schemas/content/directory.schema.json
+++ b/schemas/content/directory.schema.json
@@ -1,0 +1,41 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This file is licensed to you under the Apache License, Version 2.0 (the 'License');",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at http://www.apache.org/licenses/LICENSE-2.0"
+  ],
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://ns.adobe.com/xdm/content/directory",
+  "title": "Directory",
+  "definitions": {
+    "directory": {
+      "properties": {
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/content/directory"
+        },
+        "children": {
+          "type": "array",
+          "description": "The children of this directory.",
+          "items": {
+            "$ref": "https://ns.adobe.com/xdm/content/content#/definitions/content"
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {"$ref": "https://ns.adobe.com/xdm/content/content#/definitions/content"},
+    {"$ref": "#/definitions/directory"}
+  ],
+  "required": [
+    "name",
+    "path",
+    "@type",
+    "repository_created_date",
+    "repository_last_modified_date",
+    "children"
+  ]
+}


### PR DESCRIPTION
Baseline for Directory XDM, matches changes in original pull #96 in Adobe XDM repository.

Directory description, sample and schema files copied from original pull request.
_npm install_ and _npm test_ passing locally.

This baseline allows starting point to continue enhancing Directory proposal to address issues identified in original proposal and align with other ACP API specification changes.

I don't want to provide link to original pull request as it's located in Adobe's git repository. For Adobe employee's you will be able to locate original pull request with the pull request number (96) in Adobe's XDM git repo.