### PR TITLE
Add _page to ACPAPI Directory resource proposal

### DIFF
--- a/schemas/content/directory-page.description.md
+++ b/schemas/content/directory-page.description.md
@@ -1,0 +1,1 @@
+Directory page object contains paging information for related directory when directory result is paginated.

--- a/schemas/content/directory-page.example.1.json
+++ b/schemas/content/directory-page.example.1.json
@@ -1,7 +1,8 @@
 {
-    "orderBy": "age",
-    "order": "asc",
-    "start": "123",
-    "next": "789",
-    "count": "100"
+  "@type": "https://ns.adobe.com/xdm/content/directory-page",
+  "orderBy": "id",
+  "order": "asc",
+  "start": "123",
+  "next": "789",
+  "count": 100
 }

--- a/schemas/content/directory-page.example.1.json
+++ b/schemas/content/directory-page.example.1.json
@@ -1,0 +1,9 @@
+{
+    "orderBy": "age",
+    "order": "asc",
+    "start": "18",
+    "next": "25",
+    "property": "male",
+    "type": "image/jpeg",
+    "count": "100"
+}

--- a/schemas/content/directory-page.example.2.json
+++ b/schemas/content/directory-page.example.2.json
@@ -1,9 +1,9 @@
 {
-    "orderBy": "age",
-    "order": "asc",
-    "start": "123",
-    "next": "789",
-    "property": "male",
-    "type": "image/jpeg",
-    "count": "100"
+  "@type": "https://ns.adobe.com/xdm/content/directory-page",
+  "orderBy": "id",
+  "order": "asc",
+  "start": "123",
+  "next": "789",
+  "type": "image/jpeg",
+  "count": 100
 }

--- a/schemas/content/directory-page.example.2.json
+++ b/schemas/content/directory-page.example.2.json
@@ -3,5 +3,7 @@
     "order": "asc",
     "start": "123",
     "next": "789",
+    "property": "male",
+    "type": "image/jpeg",
     "count": "100"
 }

--- a/schemas/content/directory-page.invalid.1.json
+++ b/schemas/content/directory-page.invalid.1.json
@@ -1,8 +1,7 @@
 {
-    "orderBy": "age",
-    "order": "asc",
-    "start": "123",
-    "next": "789",
-    "property": "male",
-    "type": "image/jpeg"
+  "@type": "https://ns.adobe.com/xdm/content/directory-page",
+  "orderBy": "id",
+  "order": "asc",
+  "start": "123",
+  "next": "789"
 }

--- a/schemas/content/directory-page.invalid.1.json
+++ b/schemas/content/directory-page.invalid.1.json
@@ -3,5 +3,6 @@
     "order": "asc",
     "start": "123",
     "next": "789",
-    "count": "100"
+    "property": "male",
+    "type": "image/jpeg"
 }

--- a/schemas/content/directory-page.schema.json
+++ b/schemas/content/directory-page.schema.json
@@ -1,0 +1,66 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/content/directory-page",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Directory Page Object",
+  "type": "object",
+  "description": "Directory page object contains paging information for related directory when directory result is paginated.",
+  "definitions": {
+    "page": {
+      "properties": {
+        "xdm:orderBy": {
+          "title": "Order by property",
+          "type": "string",
+          "description": "The property by which this page is ordered.\n"
+        },
+        "xdm:order": {
+          "title": "Order direction",
+          "type": "string",
+          "description": "\"asc\" or \"desc\".\n"
+        },
+        "xdm:start": {
+          "title": "First value",
+          "type": "string",
+          "description": "The first value, in sorted order, of the orderby property on this page.\n"
+        },
+        "xdm:next": {
+          "title": "Next page start value",
+          "type": "string",
+          "description": "The start value for the next page.\n"
+        },
+        "xdm:property": {
+          "title": "Filter properties",
+          "type": "string",
+          "description": "The list of properties by which the result is filtered, if any.\n"
+        },
+        "xdm:type": {
+          "title": "Filter type value",
+          "type": "string",
+          "description": "The applied type filtering value, if any.\n"
+        },
+        "xdm:count": {
+          "title": "Number of items",
+          "type": "integer",
+          "description": "The number of items on this page.\n"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/page"
+    }
+  ],
+  "required": [
+    "orderBy",
+    "order",
+    "start",
+    "next",
+    "count"
+  ]
+}

--- a/schemas/content/directory-page.schema.json
+++ b/schemas/content/directory-page.schema.json
@@ -13,15 +13,21 @@
   "definitions": {
     "page": {
       "properties": {
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/content/directory-page"
+        },
         "xdm:orderBy": {
           "title": "Order by property",
           "type": "string",
           "description": "The property by which this page is ordered.\n"
         },
         "xdm:order": {
-          "title": "Order direction",
+          "title": "Sort order",
           "type": "string",
-          "description": "\"asc\" or \"desc\".\n"
+          "pattern": "^(asc|desc)$",
+          "description": "Sort order, either \"asc\" or \"desc\".\n"
         },
         "xdm:start": {
           "title": "First value",

--- a/schemas/content/directory.example.1.json
+++ b/schemas/content/directory.example.1.json
@@ -1,37 +1,37 @@
 {  
-  "name":"example",
-  "path":"/content/example",
-  "@type":"https://ns.adobe.com/xdm/content/directory",
-  "repository_created_date":"2017-09-26T13:27:36+00:00",
-  "repository_last_modified_date":"2017-09-26T13:31:19+00:00",
-  "children":[  
+  "name": "example",
+  "path": "/content/example",
+  "@type": "https://ns.adobe.com/xdm/content/directory",
+  "repository_created_date": "2017-09-26T13:27:36+00:00",
+  "repository_last_modified_date": "2017-09-26T13:31:19+00:00",
+  "children": [  
     {  
-      "name":"subdirectory0",
-      "path":"/content/example/subdirectory0",
-      "@type":"https://ns.adobe.com/xdm/content/directory",
-      "repository_created_date":"2017-09-26T13:27:36+00:00",
-      "repository_last_modified_date":"2017-09-26T13:31:19+00:00"
+      "name": "subdirectory0",
+      "path": "/content/example/subdirectory0",
+      "@type": "https://ns.adobe.com/xdm/content/directory",
+      "repository_created_date": "2017-09-26T13:27:36+00:00",
+      "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
     },
     {  
-      "name":"subdirectory1",
-      "path":"/content/example/subdirectory1",
-      "@type":"https://ns.adobe.com/xdm/content/directory",
-      "repository_created_date":"2017-09-26T13:27:36+00:00",
-      "repository_last_modified_date":"2017-09-26T13:31:19+00:00"
+      "name": "subdirectory1",
+      "path": "/content/example/subdirectory1",
+      "@type": "https://ns.adobe.com/xdm/content/directory",
+      "repository_created_date": "2017-09-26T13:27:36+00:00",
+      "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
     },
     {  
-      "name":"image0",
-      "path":"/content/example/image0",
-      "@type":"http://ns.adobe.com/xdm/asset",
-      "repository_created_date":"2017-09-26T13:27:36+00:00",
-      "repository_last_modified_date":"2017-09-26T13:31:19+00:00"
+      "name": "image0",
+      "path": "/content/example/image0",
+      "@type": "http://ns.adobe.com/xdm/asset",
+      "repository_created_date": "2017-09-26T13:27:36+00:00",
+      "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
     },
     {  
-      "name":"image1",
-      "path":"/content/example/image1",
-      "@type":"http://ns.adobe.com/xdm/asset",
-      "repository_created_date":"2017-09-26T13:27:36+00:00",
-      "repository_last_modified_date":"2017-09-26T13:31:19+00:00"
+      "name": "image1",
+      "path": "/content/example/image1",
+      "@type": "http://ns.adobe.com/xdm/asset",
+      "repository_created_date": "2017-09-26T13:27:36+00:00",
+      "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
     }
   ]
 }

--- a/schemas/content/directory.example.1.json
+++ b/schemas/content/directory.example.1.json
@@ -1,37 +1,37 @@
-{
-    "name": "example",
-    "path": "/content/example",
-    "@type": "https://ns.adobe.com/xdm/content/directory",
-    "repository_created_date": "2017-09-26T13:27:36+00:00",
-    "repository_last_modified_date": "2017-09-26T13:31:19+00:00",
-    "children": [
-        {
-            "name": "subdirectory0",
-            "path": "/content/example/subdirectory0",
-            "@type": "https://ns.adobe.com/xdm/content/directory",
-            "repository_created_date": "2017-09-26T13:27:36+00:00",
-            "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
-        },
-        {
-            "name": "subdirectory1",
-            "path": "/content/example/subdirectory1",
-            "@type": "https://ns.adobe.com/xdm/content/directory",
-            "repository_created_date": "2017-09-26T13:27:36+00:00",
-            "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
-        },
-        {
-            "name": "image0",
-            "path": "/content/example/image0",
-            "@type": "http://ns.adobe.com/xdm/asset",
-            "repository_created_date": "2017-09-26T13:27:36+00:00",
-            "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
-        },
-        {
-            "name": "image1",
-            "path": "/content/example/image1",
-            "@type": "http://ns.adobe.com/xdm/asset",
-            "repository_created_date": "2017-09-26T13:27:36+00:00",
-            "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
-        }
-    ]
+{  
+  "name":"example",
+  "path":"/content/example",
+  "@type":"https://ns.adobe.com/xdm/content/directory",
+  "repository_created_date":"2017-09-26T13:27:36+00:00",
+  "repository_last_modified_date":"2017-09-26T13:31:19+00:00",
+  "children":[  
+    {  
+      "name":"subdirectory0",
+      "path":"/content/example/subdirectory0",
+      "@type":"https://ns.adobe.com/xdm/content/directory",
+      "repository_created_date":"2017-09-26T13:27:36+00:00",
+      "repository_last_modified_date":"2017-09-26T13:31:19+00:00"
+    },
+    {  
+      "name":"subdirectory1",
+      "path":"/content/example/subdirectory1",
+      "@type":"https://ns.adobe.com/xdm/content/directory",
+      "repository_created_date":"2017-09-26T13:27:36+00:00",
+      "repository_last_modified_date":"2017-09-26T13:31:19+00:00"
+    },
+    {  
+      "name":"image0",
+      "path":"/content/example/image0",
+      "@type":"http://ns.adobe.com/xdm/asset",
+      "repository_created_date":"2017-09-26T13:27:36+00:00",
+      "repository_last_modified_date":"2017-09-26T13:31:19+00:00"
+    },
+    {  
+      "name":"image1",
+      "path":"/content/example/image1",
+      "@type":"http://ns.adobe.com/xdm/asset",
+      "repository_created_date":"2017-09-26T13:27:36+00:00",
+      "repository_last_modified_date":"2017-09-26T13:31:19+00:00"
+    }
+  ]
 }

--- a/schemas/content/directory.example.2.json
+++ b/schemas/content/directory.example.2.json
@@ -1,24 +1,24 @@
 {  
-  "name":"example",
-  "path":"/content/example",
-  "@type":"https://ns.adobe.com/xdm/content/directory",
-  "repository_created_date":"2017-09-26T13:27:36+00:00",
-  "repository_last_modified_date":"2017-09-26T13:31:19+00:00",
-  "_page":{  
-    "@type":"https://ns.adobe.com/xdm/content/directory-page",
-    "orderBy":"name",
-    "order":"asc",
-    "start":"subdirectory0",
-    "next":"subdirectory1",
-    "count":"1"
+  "name": "example",
+  "path": "/content/example",
+  "@type": "https://ns.adobe.com/xdm/content/directory",
+  "repository_created_date": "2017-09-26T13:27:36+00:00",
+  "repository_last_modified_date": "2017-09-26T13:31:19+00:00",
+  "_page": {  
+    "@type": "https://ns.adobe.com/xdm/content/directory-page",
+    "orderBy": "name",
+    "order": "asc",
+    "start": "subdirectory0",
+    "next": "subdirectory1",
+    "count": "1"
   },
-  "children":[  
+  "children": [  
     {  
-      "name":"subdirectory0",
-      "path":"/content/example/subdirectory0",
-      "@type":"https://ns.adobe.com/xdm/content/directory",
-      "repository_created_date":"2017-09-26T13:27:36+00:00",
-      "repository_last_modified_date":"2017-09-26T13:31:19+00:00"
+      "name": "subdirectory0",
+      "path": "/content/example/subdirectory0",
+      "@type": "https://ns.adobe.com/xdm/content/directory",
+      "repository_created_date": "2017-09-26T13:27:36+00:00",
+      "repository_last_modified_date": "2017-09-26T13:31:19+00:00"
     }
   ]
 }

--- a/schemas/content/directory.example.2.json
+++ b/schemas/content/directory.example.2.json
@@ -1,0 +1,24 @@
+{
+	"name": "example",
+	"path": "/content/example",
+	"@type": "https://ns.adobe.com/xdm/content/directory",
+	"repository_created_date": "2017-09-26T13:27:36+00:00",
+	"repository_last_modified_date": "2017-09-26T13:31:19+00:00",
+	"_page": {
+		"@type": "https://ns.adobe.com/xdm/content/directory-page",
+		"orderBy": "name",
+		"order": "asc",
+		"start": "subdirectory0",
+		"next": "subdirectory1",
+		"count": "1"
+	},
+	"children": [
+		{
+			"name": "subdirectory0",
+			"path": "/content/example/subdirectory0",
+			"@type": "https://ns.adobe.com/xdm/content/directory",
+			"repository_created_date": "2017-09-26T13:27:36+00:00",
+			"repository_last_modified_date": "2017-09-26T13:31:19+00:00"
+		}
+	]
+}

--- a/schemas/content/directory.example.2.json
+++ b/schemas/content/directory.example.2.json
@@ -1,24 +1,24 @@
-{
-	"name": "example",
-	"path": "/content/example",
-	"@type": "https://ns.adobe.com/xdm/content/directory",
-	"repository_created_date": "2017-09-26T13:27:36+00:00",
-	"repository_last_modified_date": "2017-09-26T13:31:19+00:00",
-	"_page": {
-		"@type": "https://ns.adobe.com/xdm/content/directory-page",
-		"orderBy": "name",
-		"order": "asc",
-		"start": "subdirectory0",
-		"next": "subdirectory1",
-		"count": "1"
-	},
-	"children": [
-		{
-			"name": "subdirectory0",
-			"path": "/content/example/subdirectory0",
-			"@type": "https://ns.adobe.com/xdm/content/directory",
-			"repository_created_date": "2017-09-26T13:27:36+00:00",
-			"repository_last_modified_date": "2017-09-26T13:31:19+00:00"
-		}
-	]
+{  
+  "name":"example",
+  "path":"/content/example",
+  "@type":"https://ns.adobe.com/xdm/content/directory",
+  "repository_created_date":"2017-09-26T13:27:36+00:00",
+  "repository_last_modified_date":"2017-09-26T13:31:19+00:00",
+  "_page":{  
+    "@type":"https://ns.adobe.com/xdm/content/directory-page",
+    "orderBy":"name",
+    "order":"asc",
+    "start":"subdirectory0",
+    "next":"subdirectory1",
+    "count":"1"
+  },
+  "children":[  
+    {  
+      "name":"subdirectory0",
+      "path":"/content/example/subdirectory0",
+      "@type":"https://ns.adobe.com/xdm/content/directory",
+      "repository_created_date":"2017-09-26T13:27:36+00:00",
+      "repository_last_modified_date":"2017-09-26T13:31:19+00:00"
+    }
+  ]
 }

--- a/schemas/content/directory.schema.json
+++ b/schemas/content/directory.schema.json
@@ -16,6 +16,10 @@
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/content/directory"
         },
+        "_page": {
+        	  "$ref": "https://ns.adobe.com/xdm/content/directory-page#/definitions/page",
+          "description": "Page info, included if this resource is part of paginated result."
+        },
         "children": {
           "type": "array",
           "description": "The children of this directory.",

--- a/schemas/content/directory.schema.json
+++ b/schemas/content/directory.schema.json
@@ -17,7 +17,7 @@
           "const": "https://ns.adobe.com/xdm/content/directory"
         },
         "_page": {
-        	  "$ref": "https://ns.adobe.com/xdm/content/directory-page#/definitions/page",
+          "$ref": "https://ns.adobe.com/xdm/content/directory-page#/definitions/page",
           "description": "Page info, included if this resource is part of paginated result."
         },
         "children": {


### PR DESCRIPTION
Original Directory resource proposal (# 96 in Adobe's original git repository) identified some missing items and inconsistencies.  This change proposal adds support for _page for Directory resource per ACPAPI specification.

This pull request is created against team feature branch (https://github.com/tdahlgre/xdm/tree/acpapi.directory.xdm) which includes baseline from original proposal (see #1) and will be used be several team members to address gaps / issues identified by original proposal.

See inline notes for additional details, and Platform API specification for pagination support (I'm not posting links or copies of internal references to this pull in public git location).

@mburbidgadobe, @trieloff, @lopperma - please do initial review and give any feedback you may have. I will link Boris P to this review as well when I find out his username in GitHub.

@ssheshag, @wkelley-adobe, @stlarson - please review and merge to shared branch if looks good to integrate your work with this as well. I can also merge with any changes you are making later as this is quite isolated.

_npm test_ passes locally with these changes, includes new directory sample and valid/invalid json examples for newly added _page object schema.

First time working in XDM so any feedback, guidelines and proposals welcome to make this good!
